### PR TITLE
Fixed reward overloading bug which results in incorrect rewards being used by POMDPs.solve

### DIFF
--- a/src/product.jl
+++ b/src/product.jl
@@ -74,8 +74,6 @@ function POMDPs.reward(mdp::Union{ProductMDP, ProductPOMDP}, s::ProductState{S, 
     return 0.0
 end
 
-POMDPs.reward(mdp::Union{ProductMDP, ProductPOMDP}, s::ProductState{S, Q}, a::A) where {S, A, Q} = reward(mdp, s, a, s)
-
 function POMDPs.isterminal(mdp::Union{ProductMDP, ProductPOMDP}, s::ProductState{S, Q}) where {S, Q}
     if s ∈ mdp.accepting_states || s == mdp.sink_state
         return true


### PR DESCRIPTION
It looks like this reward overloading is causing issues with the SARSOP solver not outputting any meaningful solution. I was using this code on the RockSample task; when I looked at what reward is being written into the model.pomdpx, I see that all rewards are zero since both s and s' are always the same state. My environment is

macOS 11.2.2
Julia 1.3.1

(v1.3) pkg> st
    Status `~/.julia/environments/v1.3/Project.toml`
  [8bb6e9a1] BeliefUpdaters v0.2.1
  [159f3aea] Cairo v1.0.5
  [a81c6b42] Compose v0.9.2
  [a0b5b9ef] Cxx v0.4.0
  [4b033969] DiscreteValueIteration v0.4.5
  [7f35509c] POMDPGifs v0.1.0
  [abefb91b] POMDPModelChecking v0.0.0
  [08074719] POMDPModelTools v0.3.2
  [182e52fb] POMDPPolicies v0.3.3
  [e0d0a172] POMDPSimulators v0.3.9
  [a93abf59] POMDPs v0.9.1
  [92933f4c] ProgressMeter v1.4.0
  [295af30f] Revise v3.1.12
  [de008ff0] RockSample v0.1.3
  [cef570c6] SARSOP v0.5.4
  [f11abc24] Spot v0.1.1
  [10745b16] Statistics

but I also had the same issue on a RedHat Linux server as well. Removing this reward line fixes the issue.